### PR TITLE
added preserve-data-in-the-browser 

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
   <ul>
     <li><a href="https://www.w3schools.com/html/default.asp">HTML</a></li>
     <li><a href="https://www.w3schools.com/css/default.asp">Css</a></li>
-    <li><a href="https://www.w3schools.com/javascript/default.asp>JS</a></li>
+    <li><a href="https://www.w3schools.com/javascript/default.asp">JS</a></li>
   </ul>
 </details>
 

--- a/index.html
+++ b/index.html
@@ -384,7 +384,7 @@
         id="contact-forms"
         class="contact-form"
       >
-        <section class="inputs">
+        <section class="inputs inputs-fullname">
           <div class="error" id="fullname-error"></div>
           <label for="fullname">Full Name</label>
           <input
@@ -395,7 +395,7 @@
             placeholder="Full name"
           />
         </section>
-        <section class="inputs">
+        <section class="inputs inputs-email">
           <div class="error" id="email-error"></div>
           <label for="email">Email</label>
           <input

--- a/script.js
+++ b/script.js
@@ -79,3 +79,31 @@ document.addEventListener('DOMContentLoaded', () => {
     validateFormInputs();
   });
 });
+
+// preserve-data-in-the-browser
+
+const nameField = document.querySelector('input[name="inputs-fullname"]');
+const emailField = document.querySelector('input[name="inputs-email"]');
+const messageField = document.querySelector('textarea[name="inputs-textarea"]');
+
+function saveDataToLocalStorage() {
+  const data = {
+    name: nameField.value,
+    email: emailField.value,
+    message: messageField.value,
+  };
+
+  localStorage.setItem('formData', JSON.stringify(data));
+}
+window.addEventListener('load', () => {
+  const savedData = localStorage.getItem('formData');
+  if (savedData) {
+    const data = JSON.parse(savedData);
+    nameField.value = data.name;
+    emailField.value = data.email;
+    messageField.value = data.message;
+  }
+});
+nameField.addEventListener('input', saveDataToLocalStorage);
+emailField.addEventListener('input', saveDataToLocalStorage);
+messageField.addEventListener('input', saveDataToLocalStorage);


### PR DESCRIPTION
In this project, we worked on!!

- [X]  I implemented the following interactions:

- [X] When the user changes the content of any input field, the data is saved to the local storage.

- [X] When the user loads the page, if there is any data in the local storage the input fields are pre-filled with this data.

- [X] I used the following data model:

- [X] I created a single JavaScript object with all the data from the entire form and save it in local storage. I do not create one local storage entry per input field.
